### PR TITLE
Changes to pick selected folder path

### DIFF
--- a/src/Form1.cs
+++ b/src/Form1.cs
@@ -346,7 +346,7 @@ namespace rebuild
             FolderBrowserDialog fbd = new FolderBrowserDialog();
             DialogResult result = fbd.ShowDialog();
             if (result == System.Windows.Forms.DialogResult.OK)
-                textRuta.Text = Path.GetDirectoryName(fbd.SelectedPath);
+                textRuta.Text = fbd.SelectedPath;
             else
                 textRuta.Text = "";
         }


### PR DESCRIPTION
If we have Webex .dat files inside the folder say "C:/path/to/folder/Desktop/11001100"
then
   textRuta.Text = Path.GetDirectoryName(fbd.SelectedPath);
gives path till "C:/path/to/folder/Desktop"

But we need this "C:/path/to/folder/Desktop/11001100" path to run the rebuild
which we can get directly from "fbd.SelectedPath"
   textRuta.Text = fbd.SelectedPath;